### PR TITLE
fix odcds coverage

### DIFF
--- a/source/common/upstream/od_cds_api_impl.h
+++ b/source/common/upstream/od_cds_api_impl.h
@@ -90,6 +90,7 @@ private:
   Stats::ScopePtr scope_;
   StartStatus status_;
   absl::flat_hash_set<std::string> awaiting_names_;
+  bool collection_;
   Config::SubscriptionPtr subscription_;
 };
 

--- a/test/extensions/filters/http/on_demand/on_demand_filter_test.cc
+++ b/test/extensions/filters/http/on_demand/on_demand_filter_test.cc
@@ -80,6 +80,7 @@ TEST_F(OnDemandFilterTest, TestDecodeHeadersWhenRouteAvailableButClusterIsNotAva
 TEST_F(OnDemandFilterTest, TestDecodeHeadersWhenRouteAvailableButClusterNameIsEmpty) {
   setupWithCDS();
   Http::TestRequestHeaderMapImpl headers;
+  EXPECT_CALL(decoder_callbacks_, clusterInfo()).WillOnce(Return(nullptr));
   decoder_callbacks_.route_->route_entry_.cluster_name_ = "";
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, true));
 }

--- a/test/integration/odcds_integration_test.cc
+++ b/test/integration/odcds_integration_test.cc
@@ -411,5 +411,140 @@ TEST_P(OdCdsAdsIntegrationTest, OnDemandClusterDiscoveryWorksWithClusterHeader) 
   cleanupUpstreamAndDownstream();
 }
 
+envoy::config::listener::v3::Listener buildOdCdsXdstpListener(const std::string& address) {
+  envoy::config::listener::v3::Listener listener;
+  TestUtility::loadFromYaml(fmt::format(R"EOF(
+      name: http
+      address:
+        socket_address:
+          address: {}
+          port_value: 0
+      filter_chains:
+      - filters:
+        - name: http
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: config_test
+            http_filters:
+            - name: envoy.filters.http.on_demand
+            - name: envoy.filters.http.router
+            codec_type: HTTP2
+            route_config:
+              name: local_route
+              virtual_hosts:
+              - name: local_service
+                domains: ["*"]
+                typed_per_filter_config:
+                  envoy.filters.http.on_demand:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.on_demand.v3.PerRouteConfig
+                    odcds_config:
+                      resource_api_version: V3
+                      ads: {{}}
+                    resources_locator: "xdstp://test/envoy.config.cluster.v3.Cluster/cluster_collection/*"
+                routes:
+                - match: {{ prefix: "/" }}
+                  route:
+                    cluster_header: "Pick-This-Cluster"
+)EOF",
+                                        address),
+                            listener);
+  return listener;
+}
+
+class OdCdsAdsXdstpIntegrationTest : public AdsIntegrationTest {
+public:
+  void initialize() override {
+    AdsIntegrationTest::initialize();
+
+    test_server_->waitUntilListenersReady();
+    fake_upstream_idx_ = fake_upstreams_.size();
+    auto& upstream = addFakeUpstream(FakeHttpConnection::Type::HTTP2);
+    collection_cluster_ = ConfigHelper::buildStaticCluster(
+        "xdstp://test/envoy.config.cluster.v3.Cluster/cluster_collection/bar",
+        upstream.localAddress()->ip()->port(),
+        Network::Test::getLoopbackAddressString(ipVersion()));
+    new_cluster_ =
+        ConfigHelper::buildStaticCluster("new_cluster", upstream.localAddress()->ip()->port(),
+                                         Network::Test::getLoopbackAddressString(ipVersion()));
+  }
+
+  std::size_t fake_upstream_idx_;
+  envoy::config::cluster::v3::Cluster collection_cluster_;
+  envoy::config::cluster::v3::Cluster new_cluster_;
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    IpVersionsClientTypeDeltaWildcard, OdCdsAdsXdstpIntegrationTest,
+    testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                     testing::ValuesIn(TestEnvironment::getsGrpcVersionsForTest()),
+                     // Only delta xDS is supported for on-demand CDS.
+                     testing::Values(Grpc::SotwOrDelta::Delta, Grpc::SotwOrDelta::UnifiedDelta),
+                     // Only new DSS is supported for on-demand CDS.
+                     testing::Values(OldDssOrNewDss::New)));
+
+// tests a scenario when:
+//  - making a request to an unknown cluster
+//  - odcds initiates a connection with a request for the xdstp resource
+//  - odcds request cluster resource referenced by the request.
+//  - a response contains the cluster
+//  - request is resumed
+TEST_P(OdCdsAdsXdstpIntegrationTest, OnDemandClusterDiscoveryWorksWithClusterHeader) {
+  initialize();
+
+  auto compareRequest = [this](const std::string& type_url,
+                               const std::vector<std::string>& expected_resource_subscriptions,
+                               const std::vector<std::string>& expected_resource_unsubscriptions,
+                               bool expect_node = false) {
+    return compareDeltaDiscoveryRequest(type_url, expected_resource_subscriptions,
+                                        expected_resource_unsubscriptions,
+                                        Grpc::Status::WellKnownGrpcStatus::Ok, "", expect_node);
+  };
+
+  // initial cluster query
+  EXPECT_TRUE(compareRequest(Config::TypeUrl::get().Cluster, {}, {}, true));
+  sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster,
+                                                                  {}, {}, "1");
+
+  // initial listener query
+  EXPECT_TRUE(compareRequest(Config::TypeUrl::get().Listener, {}, {}));
+  auto odcds_listener =
+      buildOdCdsXdstpListener(Network::Test::getLoopbackAddressString(ipVersion()));
+  sendDeltaDiscoveryResponse<envoy::config::listener::v3::Listener>(Config::TypeUrl::get().Listener,
+                                                                    {odcds_listener}, {}, "2");
+
+  // acks
+  EXPECT_TRUE(compareRequest(Config::TypeUrl::get().Cluster, {}, {}));
+  EXPECT_TRUE(compareRequest(Config::TypeUrl::get().Listener, {}, {}));
+
+  // listener got acked, so register the http port now.
+  test_server_->waitUntilListenersReady();
+  registerTestServerPorts({"http"});
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost.first"},
+                                                 {"Pick-This-Cluster", "new_cluster"}};
+  IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+  EXPECT_TRUE(compareRequest(Config::TypeUrl::get().Cluster,
+                             {"xdstp://test/envoy.config.cluster.v3.Cluster/cluster_collection/*"},
+                             {}));
+  sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster,
+                                                                  {collection_cluster_}, {}, "3");
+  EXPECT_TRUE(compareRequest(Config::TypeUrl::get().Cluster, {"new_cluster"}, {}));
+  sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TypeUrl::get().Cluster,
+                                                                  {new_cluster_}, {}, "4");
+
+  waitForNextUpstreamRequest(fake_upstream_idx_);
+  // Send response headers, and end_stream if there is no response body.
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+
+  response->waitForHeaders();
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  cleanupUpstreamAndDownstream();
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Just trying to help with the coverage failure in: https://storage.googleapis.com/envoy-pr/a153809/coverage/source/extensions/filters/http/on_demand/on_demand_update.cc.gcov.html

1. it seems `TestDecodeHeadersWhenRouteAvailableButClusterNameIsEmpty` exercised wrong path because clusterInfo is available by default and the `OnDemandRouteUpdate::handleOnDemandCDS` check returned early.
2. the `resources_locator` path is not covered in `createOdCdsApi`

I don't really understand the xdstp use case in odcds so I might be writing the integration test in a completely wrong manner, feel free to disregard if so : )

One thing to be noted is that GrpcCollectionSubscriptionImpl::start expect input parameter `resource_names` to be empty.